### PR TITLE
Restyle scholarship info panels to the refined cream/gold scheme

### DIFF
--- a/app/scholarships/page.tsx
+++ b/app/scholarships/page.tsx
@@ -248,7 +248,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
           <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black text-center">Landegger Program in International Business Diplomacy</h2>
           <p className="text-2xl font-semibold mb-4 text-[#b08d28] text-center">School of Foreign Service</p>
           <OrnamentalDivider className="mb-8" />
-          <div className="bg-[#fdfcf9] p-8 rounded-lg shadow-lg border border-[#d4af36]/30">
+          <div className="bg-[#fdfcf9] p-8 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36]">
             <h3 className="text-2xl font-semibold mb-4 text-[#b08d28] text-center">Global Impact Pitch Competition</h3>
             <p className="text-lg md:text-xl text-gray-800 leading-relaxed mb-6">
               Effective with Spring 2025, the Foundation has partnered with the Landegger Program within the Georgetown School of Foreign Service as a contributing sponsor of the annual Global Impact Pitch Competition (GIPC).
@@ -285,18 +285,18 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
           <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black text-center">STIA Awards</h2>
           <p className="text-2xl font-semibold mb-4 text-[#b08d28] text-center">School of Foreign Service</p>
           <OrnamentalDivider className="mb-8" />
-          <div className="bg-[#fdfcf9] p-8 rounded-lg shadow-lg border border-[#d4af36]/30">
+          <div className="bg-[#fdfcf9] p-8 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36]">
             <p className="text-lg md:text-xl text-gray-800 leading-relaxed mb-8">
               The Foundation has created in partnership with the Georgetown School of Foreign Service two Awards of $300 each celebrating students who exemplify the STIA mission, applying interdisciplinary thinking to address real world challenges through service, leadership and innovation.
             </p>
             <div className="grid md:grid-cols-2 gap-8">
-              <div className="bg-[#fdfcf9] p-6 rounded-lg shadow-md flex flex-col transform transition duration-300 hover:scale-105 border border-[#d4af36]/30">
+              <div className="bg-[#fdfcf9] p-6 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] flex flex-col border-t-2 border-[#d4af36] transition-all duration-300 ease-out hover:shadow-xl">
                 <h3 className="text-xl font-semibold mb-3 text-[#b08d28]">Delta Phi Epsilon STIA Service Award</h3>
                 <p className="text-gray-800 flex-grow">
                   The Award recognizes a graduating SFS senior who demonstrates an exceptional commitment to service and leadership, and who shows how the STIA program can be used to meaningfully engage with and improve the world around us.
                 </p>
               </div>
-              <div className="bg-[#fdfcf9] p-6 rounded-lg shadow-md flex flex-col transform transition duration-300 hover:scale-105 border border-[#d4af36]/30">
+              <div className="bg-[#fdfcf9] p-6 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] flex flex-col border-t-2 border-[#d4af36] transition-all duration-300 ease-out hover:shadow-xl">
                 <h3 className="text-xl font-semibold mb-3 text-[#b08d28]">Jack Herrity Innovation Award</h3>
                 <p className="text-gray-800 flex-grow">
                   The Award honors a graduating SFS senior who shows outstanding promise in social innovation, particularly at the intersection of science, technology and public policy. It celebrates creative forward thinking approaches to solving complex societal challenges.
@@ -310,7 +310,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
         <section className="mb-20 max-w-4xl mx-auto">
           <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black text-center">Kenneth W Bleakley Senior Foreign Service Officer Scholarships</h2>
           <OrnamentalDivider className="mb-8" />
-          <div className="bg-[#fdfcf9] p-8 rounded-lg shadow-lg border border-[#d4af36]/30">
+          <div className="bg-[#fdfcf9] p-8 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36]">
             <p className="text-lg md:text-xl text-gray-800 leading-relaxed mb-6">
               Kenneth W Bleakley had a distinguished 29-year career as a U.S. Foreign Service Officer which included serving as President George H.W. Bush&apos;s Senior Deputy U.S. Coordinator for International Communications and Information Policy, Deputy Chief of Mission in San Salvador, Director of U.S. Operations in Central America and Director of the U.S. International Refugee Program. He was President of the American Foreign Service Association and Delta Phi Epsilon Professional Foreign Service Fraternity.
             </p>
@@ -320,10 +320,10 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
           </div>
         </section>
 
-        <section className="mb-20 bg-[#d4af36] rounded-lg shadow-lg p-8 max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-black">Scholarship Information</h2>
-          <div className="w-20 h-1 bg-black mx-auto mb-6"></div>
-          <div className="bg-[#fdfcf9] p-6 rounded-lg border border-[#d4af36]/30">
+        <section className="mb-20 bg-[#f5f0e8] rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36] p-8 max-w-5xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-[#b08d28]">Scholarship Information</h2>
+          <div className="w-16 h-px bg-[#d4af36]/50 mx-auto mb-8"></div>
+          <div className="bg-transparent p-0">
             <p className="text-lg mb-10 text-center max-w-3xl mx-auto text-black">
               The trustees of the Delta Phi Epsilon Foundation for Foreign Service Education have decided to honor Kenneth W. Bleakley, a Senior Foreign Service Officer, former Trustee of the Foundation and DPE fraternity brother by the establishment of a Scholarship Award Program in his name.
             </p>
@@ -333,7 +333,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
                 { title: "Test Evidence", content: "Scholarship recipients must submit evidence of taking the US Foreign Service Officer Test or good reason for failure to do. Failure to do so will preclude eligibility for further scholarships or grants." },
                 { title: "Scholarship Amount", content: "Scholarships in the amount of $250 per recipient will be awarded to Georgetown university degree program students or graduates who apply to take the US Foreign Service Officer Test scheduled throughout the year." }
               ].map((item, index) => (
-                <div key={index} className="bg-[#fdfcf9] p-6 rounded-lg shadow-md flex flex-col transform transition duration-300 hover:scale-105 border border-[#d4af36]/30">
+                <div key={index} className="bg-[#fdfcf9] p-6 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] flex flex-col border-t-2 border-[#d4af36] transition-all duration-300 ease-out hover:shadow-xl">
                   <h3 className="text-xl font-semibold mb-3 text-[#b08d28]">{item.title}</h3>
                   <p className="text-gray-800 flex-grow">{item.content}</p>
                 </div>
@@ -430,7 +430,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
         <section className="mb-20 max-w-4xl mx-auto">
           <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black text-center">Stanley Weiss Global Business Leader Scholarships</h2>
           <OrnamentalDivider className="mb-8" />
-          <div className="bg-[#fdfcf9] p-8 rounded-lg shadow-lg border border-[#d4af36]/30">
+          <div className="bg-[#fdfcf9] p-8 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36]">
             <p className="text-lg md:text-xl text-gray-800 leading-relaxed mb-6">
               Stanley Weiss enrolled in Georgetown University School of Foreign Service after service in the U.S. Army between 1944 and 1946.
             </p>
@@ -450,10 +450,10 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>, scholarshipType
         </section>
 
       
-          <section className="mb-20 bg-[#d4af36] rounded-lg shadow-lg p-8 max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-black">Scholarship Information</h2>
-          <div className="w-20 h-1 bg-black mx-auto mb-6"></div>
-          <div className="bg-[#fdfcf9] p-6 rounded-lg border border-[#d4af36]/30">
+          <section className="mb-20 bg-[#f5f0e8] rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36] p-8 max-w-5xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-[#b08d28]">Scholarship Information</h2>
+          <div className="w-16 h-px bg-[#d4af36]/50 mx-auto mb-8"></div>
+          <div className="bg-transparent p-0">
             <p className="text-lg mb-10 text-center max-w-3xl mx-auto text-black">
             The Trustees of the Delta Phi Epsilon Foundation for Foreign Service
 Education have decided to honor Stanley Weiss, a global business leader,
@@ -466,7 +466,7 @@ Scholarship Award Program in his name. </p>
                 { title: "Eligibility for The Stanley Weiss Global Business Leader Scholarship", content: "The Stanley Weiss Global Business Leader Scholarships will be awarded to Georgetown University junior or senior students enrolled in the Global Business Fellows program at Georgetown University’s McDonough School of Business and approved by the Baratta Center for Global Business as qualified for internship work on applied global business and policy projects." },
                 { title: "Scholarship Amount", content: "These $500 scholarships will be awarded to those Global Business Fellows students who are identified by the Baratta Center for Global Business as qualifying for the internship program as one part of the Baratta Center compensation award." }
               ].map((item, index) => (
-                <div key={index} className="bg-[#fdfcf9] p-6 rounded-lg shadow-md flex flex-col transform transition duration-300 hover:scale-105 border border-[#d4af36]/30">
+                <div key={index} className="bg-[#fdfcf9] p-6 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] flex flex-col border-t-2 border-[#d4af36] transition-all duration-300 ease-out hover:shadow-xl">
                   <h3 className="text-xl font-semibold mb-3 text-[#b08d28]">{item.title}</h3>
                   <p className="text-gray-800 flex-grow">{item.content}</p>
                 </div>
@@ -558,7 +558,7 @@ Scholarship Award Program in his name. </p>
         <section className="mb-20 max-w-4xl mx-auto">
           <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black text-center">Halleck A Butts Career Diplomat Scholarships</h2>
           <OrnamentalDivider className="mb-8" />
-          <div className="bg-[#fdfcf9] p-8 rounded-lg shadow-lg border border-[#d4af36]/30">
+          <div className="bg-[#fdfcf9] p-8 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36]">
             <p className="text-lg md:text-xl text-gray-800 leading-relaxed mb-6">
               After service in World War I, Halleck A. Butts graduated from Georgetown University&#39;s School of Foreign Service in 1921 and was the first President of the Alpha Chapter of Delta Phi Epsilon National Professional Foreign Service Fraternity at Georgetown. Prior to his graduation, he was appointed U.S. Trade Commissioner at the American embassy in Tokyo and later became the U.S. Commercial Attaché. He served at the U.S. embassy in Tokyo from 1920 to 1933.
             </p>
@@ -571,10 +571,10 @@ Scholarship Award Program in his name. </p>
           </div>
         </section>
 
-        <section className="mb-20 bg-[#d4af36] rounded-lg shadow-lg p-8 max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-black">Scholarship Information</h2>
-          <div className="w-20 h-1 bg-black mx-auto mb-6"></div>
-          <div className="bg-[#fdfcf9] p-6 rounded-lg border border-[#d4af36]/30">
+        <section className="mb-20 bg-[#f5f0e8] rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] border-t-2 border-[#d4af36] p-8 max-w-5xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold mb-6 text-center text-[#b08d28]">Scholarship Information</h2>
+          <div className="w-16 h-px bg-[#d4af36]/50 mx-auto mb-8"></div>
+          <div className="bg-transparent p-0">
           <p className="text-lg mb-10 text-center max-w-3xl mx-auto text-black">
           The Trustees of the Delta Phi Epsilon Foundation for Foreign Service
 Education have decided to honor Halleck A. Butts, a distinguished career
@@ -588,7 +588,7 @@ establishment of a Scholarship Award Program in his name.</p>
                 { title: "Eligibility for The Halleck A. Butts Career Diplomat Scholarship", content: "The Halleck A. Butts Career Diplomat Scholarships will be awarded to Georgetown University students enrolled in the Dikran Izmirlian Program of Business and Global Affairs (BGA) – Georgetown’s joint undergraduate degree program between the Walsh School of Foreign Service and the McDonough School of Business." },
                 { title: "Scholarship Amount", content: "These $500 scholarships will be awarded to those Izmirlian BGA students who are identified by the program as qualifying for financial need for expenses related to the program's international study and travel requirements." }
               ].map((item, index) => (
-                <div key={index} className="bg-[#fdfcf9] p-6 rounded-lg shadow-md flex flex-col transform transition duration-300 hover:scale-105 border border-[#d4af36]/30">
+                <div key={index} className="bg-[#fdfcf9] p-6 rounded-2xl shadow-[0_2px_15px_-3px_rgba(212,175,54,0.08),0_10px_20px_-2px_rgba(0,0,0,0.04)] flex flex-col border-t-2 border-[#d4af36] transition-all duration-300 ease-out hover:shadow-xl">
                   <h3 className="text-xl font-semibold mb-3 text-[#b08d28]">{item.title}</h3>
                   <p className="text-gray-800 flex-grow">{item.content}</p>
                 </div>


### PR DESCRIPTION
Brings the scholarships page in line with the rest of the site's light cream + gold-accent palette.

- The three solid bright-gold (`#d4af36`) "Scholarship Information" panels → warm-sand sections (`#f5f0e8`) with a gold top border, soft gold-tinted shadow, gold heading, and a gold hairline divider (was a heavy black rule).
- Requirement/info sub-cards normalized to the standard card recipe (gold-tinted shadow + gold top border); removed off-scheme `shadow-md`/`hover:scale-105`/thin-border styles.

Verified: `next build` ✓, `next lint` ✓, visual pass — all three panels now match the home pillar cards / STIA cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)