### PR TITLE
Admin: contact delete + mark-read, clearer tabs, note tooltips

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,7 +12,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/app/components/ui/textarea"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/app/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/app/components/ui/tabs"
-import { Download, FileText, Edit, LogOut } from 'lucide-react'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/app/components/ui/tooltip"
+import { Download, FileText, Edit, LogOut, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { toast, ToastContainer } from 'react-toastify'
@@ -55,7 +56,13 @@ interface ContactSubmission {
   email: string
   message: string
   submission_time: string
+  read: boolean
 }
+
+// Make the scholarship tabs read clearly as clickable buttons: bordered gold
+// "pills" at rest with a hover lift, and a solid-gold filled state when active.
+const TAB_TRIGGER_CLASS =
+  'w-1/2 md:w-auto justify-center px-4 py-2 rounded-md border border-[#d4af36]/50 bg-[#fdfcf9] text-[#b08d28] font-semibold cursor-pointer transition-colors hover:bg-[#f5f0e8] hover:border-[#d4af36] hover:text-[#9a7b22] data-[state=active]:bg-[#d4af36] data-[state=active]:text-white data-[state=active]:border-[#d4af36] data-[state=active]:shadow-sm'
 
 export default function AdminDashboard() {
   const [scholarshipType, setScholarshipType] = useState<ScholarshipType>('bleakley')
@@ -116,7 +123,10 @@ export default function AdminDashboard() {
         .order('submission_time', { ascending: false })
 
       if (contactError) throw contactError
-      setContactSubmissions(contactData || [])
+      // Coerce `read` so the UI works even before the column exists in the DB.
+      setContactSubmissions(
+        (contactData || []).map((c) => ({ ...c, read: Boolean(c.read) }))
+      )
 
     } catch (error) {
       console.error('Error fetching submissions:', error)
@@ -339,6 +349,68 @@ export default function AdminDashboard() {
     }
   }
 
+  const handleContactReadChange = async (id: number, read: boolean) => {
+    // Optimistic update.
+    setContactSubmissions(prev =>
+      prev.map(sub => (sub.id === id ? { ...sub, read } : sub))
+    )
+    try {
+      const response = await fetch('/api/admin/contact', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, read }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Request failed')
+      }
+      toast.success(read ? 'Marked as read' : 'Marked as unread')
+    } catch (error) {
+      // Revert on failure.
+      setContactSubmissions(prev =>
+        prev.map(sub => (sub.id === id ? { ...sub, read: !read } : sub))
+      )
+      console.error('Error updating contact read status:', error)
+      toast.error('Failed to update read status')
+    }
+  }
+
+  const handleContactDelete = async (id: number) => {
+    if (!window.confirm('Delete this contact submission? This cannot be undone.')) {
+      return
+    }
+    const removed = contactSubmissions.find(sub => sub.id === id)
+    // Optimistic removal.
+    setContactSubmissions(prev => prev.filter(sub => sub.id !== id))
+    try {
+      const response = await fetch('/api/admin/contact', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || 'Request failed')
+      }
+      toast.success('Contact submission deleted')
+    } catch (error) {
+      // Re-insert only the removed row (preserving any concurrent changes),
+      // keeping the existing newest-first ordering.
+      if (removed) {
+        setContactSubmissions(prev =>
+          prev.some(sub => sub.id === id)
+            ? prev
+            : [...prev, removed].sort(
+                (a, b) =>
+                  new Date(b.submission_time).getTime() - new Date(a.submission_time).getTime()
+              )
+        )
+      }
+      console.error('Error deleting contact submission:', error)
+      toast.error('Failed to delete submission')
+    }
+  }
+
   const handleLogout = async () => {
     try {
       const response = await fetch('/api/admin/logout', {
@@ -375,6 +447,7 @@ export default function AdminDashboard() {
   }
 
   return (
+    <TooltipProvider delayDuration={200}>
     <div className="min-h-screen bg-[#faf8f5] font-serif">
       <ToastContainer />
       
@@ -405,11 +478,11 @@ export default function AdminDashboard() {
           </CardHeader>
           <CardContent>
             <Tabs value={scholarshipType} onValueChange={(value: string) => setScholarshipType(value as ScholarshipType)}>
-            <TabsList className="mb-4 flex flex-wrap gap-2 h-auto md:h-10 p-0 md:p-1 w-full items-stretch">
-              <TabsTrigger value="bleakley" className="w-1/2 md:w-auto justify-center">Bleakley Scholarship</TabsTrigger>
-              <TabsTrigger value="weiss" className="w-1/2 md:w-auto justify-center">Weiss Scholarship</TabsTrigger>
-              <TabsTrigger value="butts" className="w-1/2 md:w-auto justify-center">Butts Scholarship</TabsTrigger>
-              <TabsTrigger value="lemoine" className="w-1/2 md:w-auto justify-center">LeMoine Scholarship</TabsTrigger>
+            <TabsList className="mb-4 flex flex-wrap gap-2 h-auto p-0 w-full items-stretch bg-transparent">
+              <TabsTrigger value="bleakley" className={TAB_TRIGGER_CLASS}>Bleakley Scholarship</TabsTrigger>
+              <TabsTrigger value="weiss" className={TAB_TRIGGER_CLASS}>Weiss Scholarship</TabsTrigger>
+              <TabsTrigger value="butts" className={TAB_TRIGGER_CLASS}>Butts Scholarship</TabsTrigger>
+              <TabsTrigger value="lemoine" className={TAB_TRIGGER_CLASS}>LeMoine Scholarship</TabsTrigger>
             </TabsList>
 
             {(['bleakley', 'weiss', 'butts', 'lemoine'] as ScholarshipType[]).map((type) => (
@@ -607,24 +680,33 @@ export default function AdminDashboard() {
                                   setIsDialogOpen(open)
                                   if (!open) setEditingNotes(null)
                                 }}>
-                                  <DialogTrigger asChild>
-                                    <Button 
-                                      variant="outline" 
-                                      onClick={() => {
-                                        setEditingNotes({ 
-                                          id: submission.id, 
-                                          notes: submission.admin_notes,
-                                          scholarshipType: scholarshipType
-                                        })
-                                        setIsDialogOpen(true)
-                                      }}
-                                    >
-                                      <Edit className="h-4 w-4 mr-2" />
-                                      {submission.admin_notes 
-                                        ? `${submission.admin_notes.substring(0, 20)}...` 
-                                        : 'Add Notes'}
-                                    </Button>
-                                  </DialogTrigger>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <DialogTrigger asChild>
+                                        <Button
+                                          variant="outline"
+                                          onClick={() => {
+                                            setEditingNotes({
+                                              id: submission.id,
+                                              notes: submission.admin_notes,
+                                              scholarshipType: scholarshipType
+                                            })
+                                            setIsDialogOpen(true)
+                                          }}
+                                        >
+                                          <Edit className="h-4 w-4 mr-2" />
+                                          {submission.admin_notes
+                                            ? `${submission.admin_notes.substring(0, 20)}...`
+                                            : 'Add Notes'}
+                                        </Button>
+                                      </DialogTrigger>
+                                    </TooltipTrigger>
+                                    {submission.admin_notes && (
+                                      <TooltipContent side="top" align="end">
+                                        {submission.admin_notes}
+                                      </TooltipContent>
+                                    )}
+                                  </Tooltip>
                                   <DialogContent>
                                     <DialogHeader>
                                       <DialogTitle>Admin Notes for {submission.full_name}</DialogTitle>
@@ -774,24 +856,33 @@ export default function AdminDashboard() {
                                 setIsDialogOpen(open)
                                 if (!open) setEditingNotes(null)
                               }}>
-                                <DialogTrigger asChild>
-                                  <Button 
-                                    variant="outline" 
-                                    onClick={() => {
-                                      setEditingNotes({ 
-                                        id: submission.id, 
-                                        notes: submission.admin_notes,
-                                        scholarshipType: scholarshipType
-                                      })
-                                      setIsDialogOpen(true)
-                                    }}
-                                  >
-                                    <Edit className="h-4 w-4 mr-2" />
-                                    {submission.admin_notes 
-                                      ? `${submission.admin_notes.substring(0, 20)}...` 
-                                      : 'Add Notes'}
-                                  </Button>
-                                </DialogTrigger>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <DialogTrigger asChild>
+                                      <Button
+                                        variant="outline"
+                                        onClick={() => {
+                                          setEditingNotes({
+                                            id: submission.id,
+                                            notes: submission.admin_notes,
+                                            scholarshipType: scholarshipType
+                                          })
+                                          setIsDialogOpen(true)
+                                        }}
+                                      >
+                                        <Edit className="h-4 w-4 mr-2" />
+                                        {submission.admin_notes
+                                          ? `${submission.admin_notes.substring(0, 20)}...`
+                                          : 'Add Notes'}
+                                      </Button>
+                                    </DialogTrigger>
+                                  </TooltipTrigger>
+                                  {submission.admin_notes && (
+                                    <TooltipContent side="top">
+                                      {submission.admin_notes}
+                                    </TooltipContent>
+                                  )}
+                                </Tooltip>
                                 <DialogContent>
                                   <DialogHeader>
                                     <DialogTitle>Admin Notes for {submission.full_name}</DialogTitle>
@@ -839,13 +930,15 @@ export default function AdminDashboard() {
               </div>
 
               <div className="overflow-x-auto">
-              <Table className="min-w-[800px]">
+              <Table className="min-w-[900px]">
                 <TableHeader>
                   <TableRow>
+                    <TableHead className="w-[80px]">Read</TableHead>
                     <TableHead>Full Name</TableHead>
                     <TableHead>Email</TableHead>
                     <TableHead>Message</TableHead>
                     <TableHead>Submitted At</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -856,9 +949,27 @@ export default function AdminDashboard() {
                     )
                     .map((submission) => (
                       <TableRow key={submission.id}>
-                        <TableCell>{submission.full_name}</TableCell>
-                        <TableCell>{submission.email}</TableCell>
                         <TableCell>
+                          <Checkbox
+                            checked={submission.read}
+                            aria-label={submission.read ? 'Mark as unread' : 'Mark as read'}
+                            onCheckedChange={(checked) =>
+                              handleContactReadChange(submission.id, checked === true)
+                            }
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <span className={submission.read ? 'text-gray-700' : 'font-semibold text-black'}>
+                            {submission.full_name}
+                          </span>
+                          {!submission.read && (
+                            <span className="ml-2 inline-block align-middle rounded-full bg-[#d4af36]/15 px-2 py-0.5 text-xs font-medium text-[#b08d28]">
+                              New
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell className={submission.read ? 'opacity-60' : undefined}>{submission.email}</TableCell>
+                        <TableCell className={submission.read ? 'opacity-60' : undefined}>
                           <Dialog>
                             <DialogTrigger asChild>
                               <Button variant="link">
@@ -869,17 +980,38 @@ export default function AdminDashboard() {
                               <DialogHeader>
                                 <DialogTitle>Full Message</DialogTitle>
                               </DialogHeader>
-                              <div className="mt-4 max-h-[60vh] overflow-y-auto">
+                              <div className="mt-4 max-h-[60vh] overflow-y-auto whitespace-pre-wrap">
                                 {submission.message}
                               </div>
                             </DialogContent>
                           </Dialog>
                         </TableCell>
-                        <TableCell>
+                        <TableCell className={submission.read ? 'opacity-60' : undefined}>
                           {new Date(submission.submission_time).toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label="Delete submission"
+                            onClick={() => handleContactDelete(submission.id)}
+                            className="text-gray-500 hover:text-red-600 hover:bg-red-50"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
                         </TableCell>
                       </TableRow>
                     ))}
+                  {contactSubmissions.filter(submission =>
+                    submission.full_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                    submission.email.toLowerCase().includes(searchTerm.toLowerCase())
+                  ).length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6} className="text-center text-gray-500 py-8">
+                        No contact submissions.
+                      </TableCell>
+                    </TableRow>
+                  )}
                 </TableBody>
               </Table>
               </div>
@@ -909,5 +1041,6 @@ export default function AdminDashboard() {
         </div>
       </footer>
     </div>
+    </TooltipProvider>
   )
 }

--- a/app/api/admin/contact/route.ts
+++ b/app/api/admin/contact/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@supabase/supabase-js'
+
+// Contact submissions are mutated only by the admin. The public site uses the
+// anon key (insert-only), so delete / mark-read run server-side with the
+// service-role key and are gated behind the same admin_session cookie the rest
+// of the dashboard uses. The middleware lets all /api/ routes through without
+// auth, so the cookie check below is the actual guard for these endpoints.
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+function isAdmin(): boolean {
+  return cookies().get('admin_session')?.value === 'authenticated'
+}
+
+function getAdminClient() {
+  if (!supabaseUrl || !serviceRoleKey) return null
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+
+async function parseId(request: Request): Promise<number | null> {
+  try {
+    const body = await request.json()
+    const id = body?.id
+    return typeof id === 'number' && Number.isFinite(id) ? id : null
+  } catch {
+    return null
+  }
+}
+
+// Mark a contact submission read / unread.
+export async function PATCH(request: Request) {
+  if (!isAdmin()) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = getAdminClient()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+  }
+
+  let body: { id?: unknown; read?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const id = body?.id
+  const read = body?.read
+  if (typeof id !== 'number' || !Number.isFinite(id) || typeof read !== 'boolean') {
+    return NextResponse.json(
+      { error: 'id (number) and read (boolean) are required' },
+      { status: 400 }
+    )
+  }
+
+  const { error } = await supabase
+    .from('contact_form_submissions')
+    .update({ read })
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error updating contact submission read state:', error)
+    return NextResponse.json({ error: 'Failed to update submission' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}
+
+// Permanently delete a contact submission.
+export async function DELETE(request: Request) {
+  if (!isAdmin()) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = getAdminClient()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+  }
+
+  const id = await parseId(request)
+  if (id === null) {
+    return NextResponse.json({ error: 'id (number) is required' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('contact_form_submissions')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    console.error('Error deleting contact submission:', error)
+    return NextResponse.json({ error: 'Failed to delete submission' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-sm whitespace-pre-wrap break-words rounded-lg border-t-2 border-[#d4af36] bg-[#fdfcf9] px-4 py-3 text-sm leading-relaxed text-gray-800 shadow-[0_4px_25px_-3px_rgba(212,175,54,0.18),0_15px_30px_-2px_rgba(0,0,0,0.10)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/db/add_contact_read_column.sql
+++ b/db/add_contact_read_column.sql
@@ -1,0 +1,9 @@
+-- Adds a `read` flag to contact form submissions so the admin dashboard can
+-- mark messages as read / unread.
+--
+-- Run this once in the Supabase project (Dashboard → SQL Editor) before the
+-- "mark as read" feature will persist. It is idempotent and safe to re-run.
+-- (Deleting submissions does not require this column.)
+
+ALTER TABLE contact_form_submissions
+  ADD COLUMN IF NOT EXISTS read boolean NOT NULL DEFAULT false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.2",
+        "@radix-ui/react-tooltip": "^1.2.10",
         "@react-pdf-viewer/core": "^3.12.0",
         "@shadcn/ui": "^0.0.4",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
@@ -1257,6 +1258,396 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
+      "integrity": "sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.1",
+        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+      "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+      "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+      "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1278,6 +1669,39 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.2",
+    "@radix-ui/react-tooltip": "^1.2.10",
     "@react-pdf-viewer/core": "^3.12.0",
     "@shadcn/ui": "^0.0.4",
     "@supabase/auth-helpers-nextjs": "^0.10.0",


### PR DESCRIPTION
## Contact Form Submissions
- **Mark read/unread** — checkbox column. Unread rows: bold name + gold "New" badge; read rows dim their content cells (delete control stays full-opacity).
- **Delete** — per-row trash button with a confirm dialog; optimistic removal with a row-level revert that preserves concurrent edits.
- Both actions go through a **new cookie-guarded service-role API route** (`app/api/admin/contact`), so the public anon key can't delete/modify contact data. Returns generic client errors (no DB-internals leak). Verified: returns 401 when unauthenticated.

## Scholarship tabs
- Restyled the Bleakley/Weiss/Butts/LeMoine tabs as clearly-clickable gold "pill" buttons with a solid-gold active state and hover lift (previously read as plain text).

## Admin Notes
- Hovering a Notes button now shows the **full note in a tooltip** (new Radix `Tooltip` component, portaled so it isn't clipped by the table's horizontal scroll).

## One-time migration required (mark-as-read only; delete works without it)
Run `db/add_contact_read_column.sql` in Supabase → SQL Editor:
```sql
ALTER TABLE contact_form_submissions
  ADD COLUMN IF NOT EXISTS read boolean NOT NULL DEFAULT false;
```

## Verification
- `tsc --noEmit` clean, `next lint` clean.
- Admin page renders 200 with new columns/tabs; API route returns 401 unauthenticated.
- Diff adversarially reviewed (multi-agent); 3 confirmed findings fixed (delete-revert clobbering, error-message leak, delete-button dimming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)